### PR TITLE
Support for async actions

### DIFF
--- a/SerialQueue/SerialQueue/SerialQueue.cs
+++ b/SerialQueue/SerialQueue/SerialQueue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace Threading
@@ -8,16 +8,19 @@ namespace Threading
         readonly object _locker = new object();
         WeakReference<Task> _lastTask;
 
-        public Task Enqueue(Action action)
+        public Task EnqueueAction(Action action)
         {
-            return Enqueue<object>(() => {
+            return EnqueueFunction<object>(() => {
                 action();
                 return null;
             });
         }
 
-        public Task<T> Enqueue<T>(Func<T> function)
+        public Task<T> EnqueueFunction<T>(Func<T> function)
         {
+            if (typeof(T).Equals(typeof(Task)))
+                throw new InvalidOperationException("You provided async function - use EnqueueAsyncFunction for this.");
+
             lock (_locker)
             {
                 Task lastTask = null;
@@ -36,6 +39,47 @@ namespace Threading
                 return resultTask;
             }
         }
+
+        public Task EnqueueAsyncFunction(Func<Task> function)
+        {
+            lock (_locker)
+            {
+                Task lastTask = null;
+                Task resultTask = null;
+
+                if (_lastTask != null && _lastTask.TryGetTarget(out lastTask))
+                {
+                    resultTask = lastTask.ContinueWith(async _ => await function.Invoke()).Unwrap();
+                }
+                else
+                {
+                    resultTask = Task.Run(async () => await function.Invoke());
+                }
+
+                _lastTask = new WeakReference<Task>(resultTask);
+                return resultTask;
+            }
+        }
+
+        public Task<T> EnqueueAsyncFunction<T>(Func<Task<T>> function)
+        {
+            lock (_locker)
+            {
+                Task lastTask = null;
+                Task<T> resultTask = null;
+
+                if (_lastTask != null && _lastTask.TryGetTarget(out lastTask))
+                {
+                    resultTask = lastTask.ContinueWith(async _ => await function.Invoke()).Unwrap();
+                }
+                else
+                {
+                    resultTask = Task.Run(async () => await function.Invoke());
+                }
+
+                _lastTask = new WeakReference<Task>(resultTask);
+                return resultTask;
+            }
+        }
     }
 }
-

--- a/SerialQueue/Tests/Test.cs
+++ b/SerialQueue/Tests/Test.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using System;
 using Threading;
 using System.Collections.Generic;
@@ -46,10 +46,87 @@ namespace Tests
             // Act
 
             foreach (var number in range) {
-                tasks.Add(queue.Enqueue(() => list.Add(number)));
+                tasks.Add(queue.EnqueueAction(() => list.Add(number)));
             }
 
             await Task.WhenAll(tasks);
+
+            // Assert
+
+            Assert.True(range.SequenceEqual(list));
+        }
+
+        [Test]
+        public async Task QueueAsyncFunctionAsNormalFunction()
+        {
+            // Assign
+
+            var queue = new SerialQueue();
+            bool success = false;
+
+            // Act
+
+            try
+            {
+                await queue.EnqueueFunction(async () =>
+                {
+                    await Task.Delay(50);
+                });
+                success = true;
+            }
+            catch (Exception)
+            {
+            }
+
+            Assert.False(success);
+        }
+
+        [Test]
+        public async Task QueueAsyncFunction()
+        {
+            // Assign
+
+            var queue = new SerialQueue();
+            var list = new List<int>();
+            var tasks = new List<Task>();
+            var range = Enumerable.Range(0, 100);
+
+            // Act
+
+            foreach (var number in range) {
+                tasks.Add(queue.EnqueueAsyncFunction(async () =>
+                {
+                    await Task.Delay(50);
+                    list.Add(number);
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Assert
+
+            Assert.True(range.SequenceEqual(list));
+        }
+
+        [Test]
+        public async Task QueueAsyncFunctionWithResult()
+        {
+            // Assign
+
+            var queue = new SerialQueue();
+            var list = new List<int>();
+            var tasks = new List<Task>();
+            var range = Enumerable.Range(0, 100);
+
+            // Act
+
+            foreach (var number in range) {
+                list.Add(await queue.EnqueueAsyncFunction(async () =>
+                {
+                    await Task.Delay(50);
+                    return number;
+                }));
+            }
 
             // Assert
 
@@ -69,7 +146,7 @@ namespace Tests
             // Act
 
             foreach (var number in range) {
-                tasks.Add(queue.Enqueue(() => {
+                tasks.Add(queue.EnqueueFunction(() => {
                     list.Add(number);
                     return number;
                 }));
@@ -96,7 +173,7 @@ namespace Tests
             var counter = 0;
             for (int i = 0; i < count; i++) {
                 Task.Run(() => {
-                    queue.Enqueue(() => list.Add(counter++));
+                    queue.EnqueueAction(() => list.Add(counter++));
                 });
             }
 


### PR DESCRIPTION
I've discovered that when you call this:
```
await queue.Enqueue(async () =>
{
     await Task.Delay(5000);
     Debug.WriteLine("done");
});
Debug.WriteLine("awaited");
```
`awaited` is printed earlier than `done`, which should not happen.

So I added two other methods that support this and renamed the `Enqueue` method and also updated tests.
At first I tried to do this by overloading the original method, but due to the nature of lambda definition, I've come to a conclusion that it's not possible to do this safely with overloading.

So now we have `EnqueueAction`, `EnqueueFunction` and `EnqueueAsyncFunction` and user needs to use the correct one. If he tries to call `queue.EnqueueFunction(async () => { ... })`, an error will be thrown, because it's not safe - it returns an unwrapped Task.

Do you like my contribution? 😉 